### PR TITLE
Allow custom Executor to perform token refresh

### DIFF
--- a/app/java/net/openid/appauthdemo/TokenActivity.java
+++ b/app/java/net/openid/appauthdemo/TokenActivity.java
@@ -332,7 +332,7 @@ public class TokenActivity extends AppCompatActivity {
         mStateManager.getCurrent().performActionWithFreshTokens(mAuthService, this::fetchUserInfo);
     }
 
-    @MainThread
+    @WorkerThread
     private void fetchUserInfo(String accessToken, String idToken, AuthorizationException ex) {
         if (ex != null) {
             Log.e(TAG, "Token refresh failed when fetching user info");

--- a/library/javatests/net/openid/appauth/AuthStateTest.java
+++ b/library/javatests/net/openid/appauth/AuthStateTest.java
@@ -36,6 +36,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
 import java.util.Collections;
+import java.util.concurrent.Executor;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -52,6 +54,15 @@ public class AuthStateTest {
     private static final Long TWO_MINUTES = 120000L;
 
     private TestClock mClock;
+    /**
+     *
+     */
+    private Executor mExecutor = new Executor() {
+        @Override
+        public void execute(Runnable runnable) {
+            runnable.run();
+        }
+    };
 
     @Before
     public void setUp() {
@@ -61,6 +72,7 @@ public class AuthStateTest {
     @Test
     public void testInitialState() {
         AuthState state = new AuthState();
+
         assertThat(state.isAuthorized()).isFalse();
 
         assertThat(state.getAccessToken()).isNull();
@@ -412,6 +424,7 @@ public class AuthStateTest {
                 .build();
         TokenResponse tokenResp = getTestAuthCodeExchangeResponse();
         AuthState state = new AuthState(authResp, tokenResp, null);
+        state.setTokenRefreshExecutor(mExecutor);
 
         AuthorizationService service = mock(AuthorizationService.class);
         AuthState.AuthStateAction action = mock(AuthState.AuthStateAction.class);
@@ -470,6 +483,7 @@ public class AuthStateTest {
         verify(service, times(1)).performTokenRequest(
                 requestCaptor.capture(),
                 any(ClientAuthentication.class),
+                any(Executor.class),
                 callbackCaptor.capture());
 
         assertThat(requestCaptor.getValue().refreshToken).isEqualTo(tokenResp.refreshToken);
@@ -545,6 +559,7 @@ public class AuthStateTest {
         verify(service, times(1)).performTokenRequest(
             requestCaptor.capture(),
             any(ClientAuthentication.class),
+            any(Executor.class),
             callbackCaptor.capture());
 
         assertThat(requestCaptor.getValue().refreshToken).isEqualTo(tokenResp.refreshToken);

--- a/library/javatests/net/openid/appauth/AuthStateTest.java
+++ b/library/javatests/net/openid/appauth/AuthStateTest.java
@@ -54,15 +54,6 @@ public class AuthStateTest {
     private static final Long TWO_MINUTES = 120000L;
 
     private TestClock mClock;
-    /**
-     *
-     */
-    private Executor mExecutor = new Executor() {
-        @Override
-        public void execute(Runnable runnable) {
-            runnable.run();
-        }
-    };
 
     @Before
     public void setUp() {
@@ -424,13 +415,21 @@ public class AuthStateTest {
                 .build();
         TokenResponse tokenResp = getTestAuthCodeExchangeResponse();
         AuthState state = new AuthState(authResp, tokenResp, null);
-        state.setTokenRefreshExecutor(mExecutor);
 
         AuthorizationService service = mock(AuthorizationService.class);
         AuthState.AuthStateAction action = mock(AuthState.AuthStateAction.class);
 
         // at this point in time, the access token will not be considered to be expired
         mClock.currentTime.set(ONE_SECOND);
+
+        // Directly invoke the action
+        state.setTokenRefreshExecutor(new Executor() {
+            @Override
+            public void execute(Runnable runnable) {
+                runnable.run();
+            }
+        });
+
         state.performActionWithFreshTokens(
                 service,
                 NoClientAuthentication.INSTANCE,

--- a/library/javatests/net/openid/appauth/AuthorizationServiceTest.java
+++ b/library/javatests/net/openid/appauth/AuthorizationServiceTest.java
@@ -50,6 +50,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.util.Map;
+import java.util.concurrent.Executor;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
@@ -122,6 +123,13 @@ public class AuthorizationServiceTest {
     @Mock Context mContext;
     @Mock CustomTabsClient mClient;
     @Mock CustomTabManager mCustomTabManager;
+
+    private Executor mExecutor = new Executor() {
+        @Override
+        public void execute(Runnable runnable) {
+            runnable.run();
+        }
+    };
 
     @Before
     @SuppressWarnings("ResourceType")
@@ -236,7 +244,7 @@ public class AuthorizationServiceTest {
         when(mHttpConnection.getRequestProperty("Accept")).thenReturn(null);
         when(mHttpConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
         TokenRequest request = getTestAuthCodeExchangeRequest();
-        mService.performTokenRequest(request, mAuthCallback);
+        mService.performTokenRequest(request, mExecutor, mAuthCallback);
         mAuthCallback.waitForCallback();
         assertTokenResponse(mAuthCallback.response, request);
         String postBody = mOutputStream.toString();
@@ -265,7 +273,7 @@ public class AuthorizationServiceTest {
         TokenRequest request = getTestAuthCodeExchangeRequestBuilder()
                 .setNonce(TEST_NONCE)
                 .build();
-        mService.performTokenRequest(request, mAuthCallback);
+        mService.performTokenRequest(request, mExecutor, mAuthCallback);
         mAuthCallback.waitForCallback();
         assertTokenResponse(mAuthCallback.response, request, idToken);
     }
@@ -279,7 +287,7 @@ public class AuthorizationServiceTest {
         TokenRequest request = getTestAuthCodeExchangeRequest();
 
         ClientSecretBasic clientAuth = new ClientSecretBasic("SUPER_SECRET");
-        mService.performTokenRequest(request, clientAuth, mAuthCallback);
+        mService.performTokenRequest(request, clientAuth, mExecutor, mAuthCallback);
         mAuthCallback.waitForCallback();
         assertTokenResponse(mAuthCallback.response, request);
         String postBody = mOutputStream.toString();
@@ -315,7 +323,7 @@ public class AuthorizationServiceTest {
         when(mHttpConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
         when(mHttpConnection.getInputStream()).thenReturn(is);
         TokenRequest request = getTestAuthCodeExchangeRequest();
-        mService.performTokenRequest(request, csb, mAuthCallback);
+        mService.performTokenRequest(request, csb, mExecutor, mAuthCallback);
         mAuthCallback.waitForCallback();
         assertTokenResponse(mAuthCallback.response, request);
         String postBody = mOutputStream.toString();
@@ -331,7 +339,7 @@ public class AuthorizationServiceTest {
         when(mHttpConnection.getInputStream()).thenReturn(is);
         when(mHttpConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
         TokenRequest request = getTestAuthCodeExchangeRequest();
-        mService.performTokenRequest(request, csp, mAuthCallback);
+        mService.performTokenRequest(request, csp, mExecutor, mAuthCallback);
         mAuthCallback.waitForCallback();
         assertTokenResponse(mAuthCallback.response, request);
 
@@ -348,7 +356,7 @@ public class AuthorizationServiceTest {
         when(mHttpConnection.getErrorStream()).thenReturn(is);
         when(mHttpConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_BAD_REQUEST);
         TokenRequest request = getTestAuthCodeExchangeRequest();
-        mService.performTokenRequest(request, csp, mAuthCallback);
+        mService.performTokenRequest(request, csp, mExecutor, mAuthCallback);
         mAuthCallback.waitForCallback();
         assertInvalidGrant(mAuthCallback.error);
     }
@@ -360,7 +368,7 @@ public class AuthorizationServiceTest {
         when(mHttpConnection.getErrorStream()).thenReturn(is);
         when(mHttpConnection.getResponseCode()).thenReturn(199);
         TokenRequest request = getTestAuthCodeExchangeRequest();
-        mService.performTokenRequest(request, csp, mAuthCallback);
+        mService.performTokenRequest(request, csp, mExecutor, mAuthCallback);
         mAuthCallback.waitForCallback();
         assertInvalidGrant(mAuthCallback.error);
     }
@@ -372,7 +380,7 @@ public class AuthorizationServiceTest {
         when(mHttpConnection.getErrorStream()).thenReturn(is);
         when(mHttpConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_BAD_REQUEST);
         TokenRequest request = getTestAuthCodeExchangeRequest();
-        mService.performTokenRequest(request, csp, mAuthCallback);
+        mService.performTokenRequest(request, csp, mExecutor, mAuthCallback);
         mAuthCallback.waitForCallback();
         assertInvalidGrantWithNoDescription(mAuthCallback.error);
     }
@@ -382,7 +390,7 @@ public class AuthorizationServiceTest {
         Exception ex = new IOException();
         when(mHttpConnection.getInputStream()).thenThrow(ex);
         when(mHttpConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
-        mService.performTokenRequest(getTestAuthCodeExchangeRequest(), mAuthCallback);
+        mService.performTokenRequest(getTestAuthCodeExchangeRequest(), mExecutor, mAuthCallback);
         mAuthCallback.waitForCallback();
         assertNotNull(mAuthCallback.error);
         assertEquals(GeneralErrors.NETWORK_ERROR, mAuthCallback.error);

--- a/library/javatests/net/openid/appauth/AuthorizationServiceTest.java
+++ b/library/javatests/net/openid/appauth/AuthorizationServiceTest.java
@@ -50,7 +50,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.util.Map;
-import java.util.concurrent.Executor;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
@@ -123,13 +122,6 @@ public class AuthorizationServiceTest {
     @Mock Context mContext;
     @Mock CustomTabsClient mClient;
     @Mock CustomTabManager mCustomTabManager;
-
-    private Executor mExecutor = new Executor() {
-        @Override
-        public void execute(Runnable runnable) {
-            runnable.run();
-        }
-    };
 
     @Before
     @SuppressWarnings("ResourceType")
@@ -244,7 +236,7 @@ public class AuthorizationServiceTest {
         when(mHttpConnection.getRequestProperty("Accept")).thenReturn(null);
         when(mHttpConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
         TokenRequest request = getTestAuthCodeExchangeRequest();
-        mService.performTokenRequest(request, mExecutor, mAuthCallback);
+        mService.performTokenRequest(request, mAuthCallback);
         mAuthCallback.waitForCallback();
         assertTokenResponse(mAuthCallback.response, request);
         String postBody = mOutputStream.toString();
@@ -273,7 +265,7 @@ public class AuthorizationServiceTest {
         TokenRequest request = getTestAuthCodeExchangeRequestBuilder()
                 .setNonce(TEST_NONCE)
                 .build();
-        mService.performTokenRequest(request, mExecutor, mAuthCallback);
+        mService.performTokenRequest(request, mAuthCallback);
         mAuthCallback.waitForCallback();
         assertTokenResponse(mAuthCallback.response, request, idToken);
     }
@@ -287,7 +279,7 @@ public class AuthorizationServiceTest {
         TokenRequest request = getTestAuthCodeExchangeRequest();
 
         ClientSecretBasic clientAuth = new ClientSecretBasic("SUPER_SECRET");
-        mService.performTokenRequest(request, clientAuth, mExecutor, mAuthCallback);
+        mService.performTokenRequest(request, clientAuth, mAuthCallback);
         mAuthCallback.waitForCallback();
         assertTokenResponse(mAuthCallback.response, request);
         String postBody = mOutputStream.toString();
@@ -323,7 +315,7 @@ public class AuthorizationServiceTest {
         when(mHttpConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
         when(mHttpConnection.getInputStream()).thenReturn(is);
         TokenRequest request = getTestAuthCodeExchangeRequest();
-        mService.performTokenRequest(request, csb, mExecutor, mAuthCallback);
+        mService.performTokenRequest(request, csb, mAuthCallback);
         mAuthCallback.waitForCallback();
         assertTokenResponse(mAuthCallback.response, request);
         String postBody = mOutputStream.toString();
@@ -339,7 +331,7 @@ public class AuthorizationServiceTest {
         when(mHttpConnection.getInputStream()).thenReturn(is);
         when(mHttpConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
         TokenRequest request = getTestAuthCodeExchangeRequest();
-        mService.performTokenRequest(request, csp, mExecutor, mAuthCallback);
+        mService.performTokenRequest(request, csp, mAuthCallback);
         mAuthCallback.waitForCallback();
         assertTokenResponse(mAuthCallback.response, request);
 
@@ -356,7 +348,7 @@ public class AuthorizationServiceTest {
         when(mHttpConnection.getErrorStream()).thenReturn(is);
         when(mHttpConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_BAD_REQUEST);
         TokenRequest request = getTestAuthCodeExchangeRequest();
-        mService.performTokenRequest(request, csp, mExecutor, mAuthCallback);
+        mService.performTokenRequest(request, csp, mAuthCallback);
         mAuthCallback.waitForCallback();
         assertInvalidGrant(mAuthCallback.error);
     }
@@ -368,7 +360,7 @@ public class AuthorizationServiceTest {
         when(mHttpConnection.getErrorStream()).thenReturn(is);
         when(mHttpConnection.getResponseCode()).thenReturn(199);
         TokenRequest request = getTestAuthCodeExchangeRequest();
-        mService.performTokenRequest(request, csp, mExecutor, mAuthCallback);
+        mService.performTokenRequest(request, csp, mAuthCallback);
         mAuthCallback.waitForCallback();
         assertInvalidGrant(mAuthCallback.error);
     }
@@ -380,7 +372,7 @@ public class AuthorizationServiceTest {
         when(mHttpConnection.getErrorStream()).thenReturn(is);
         when(mHttpConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_BAD_REQUEST);
         TokenRequest request = getTestAuthCodeExchangeRequest();
-        mService.performTokenRequest(request, csp, mExecutor, mAuthCallback);
+        mService.performTokenRequest(request, csp, mAuthCallback);
         mAuthCallback.waitForCallback();
         assertInvalidGrantWithNoDescription(mAuthCallback.error);
     }
@@ -390,7 +382,7 @@ public class AuthorizationServiceTest {
         Exception ex = new IOException();
         when(mHttpConnection.getInputStream()).thenThrow(ex);
         when(mHttpConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
-        mService.performTokenRequest(getTestAuthCodeExchangeRequest(), mExecutor, mAuthCallback);
+        mService.performTokenRequest(getTestAuthCodeExchangeRequest(), mAuthCallback);
         mAuthCallback.waitForCallback();
         assertNotNull(mAuthCallback.error);
         assertEquals(GeneralErrors.NETWORK_ERROR, mAuthCallback.error);


### PR DESCRIPTION
The public interfaces of `AuthState` and `AuthorizationService` now allow specifying a custom `Executor` when refreshing the token. By default, the task will be performed on the `AsyncTask.THREAD_POOL_EXECUTOR`.

```java
// Allow to set a custom Executor.
mAuthState.setTokenRefreshExecutor(mExecutor);

mAuthState.performActionWithFreshTokens(mAuthorizationService, new AuthState.AuthStateAction() {
    @Override
    public void execute(@Nullable String accessToken, @Nullable String idToken, @Nullable AuthorizationException ex) {
        // This completion will run on mExecutor worker thread.
    }
});
```