### PR TITLE
Add AuthState update listener interface

### DIFF
--- a/library/java/net/openid/appauth/AuthState.java
+++ b/library/java/net/openid/appauth/AuthState.java
@@ -77,6 +77,8 @@ public class AuthState {
     @Nullable
     private AuthorizationException mAuthorizationException;
 
+    private List<AuthStateListener> mListeners = new ArrayList<AuthStateListener>();
+
     private final Object mPendingActionsSyncObject = new Object();
     private List<AuthStateAction> mPendingActions;
     private boolean mNeedsTokenRefreshOverride;
@@ -418,6 +420,7 @@ public class AuthState {
             if (authException.type == AuthorizationException.TYPE_OAUTH_TOKEN_ERROR) {
                 mAuthorizationException = authException;
             }
+            notifyUpdateFailure(authException);
             return;
         }
 
@@ -428,6 +431,8 @@ public class AuthState {
         if (tokenResponse.refreshToken != null) {
             mRefreshToken = tokenResponse.refreshToken;
         }
+
+        notifyUpdate();
     }
 
     /**
@@ -726,6 +731,22 @@ public class AuthState {
         return jsonDeserialize(new JSONObject(jsonStr));
     }
 
+    private void notifyUpdate() {
+        for (AuthStateListener listener : mListeners) {
+            listener.authStateDidUpdate(this);
+        }
+    }
+
+    private void notifyUpdateFailure(AuthorizationException ex) {
+        for (AuthStateListener listener : mListeners) {
+            listener.authStateDidFailToUpdate(ex);
+        }
+    }
+
+    public void addUpdateListener(AuthStateListener listener) {
+        mListeners.add(listener);
+    }
+
     /**
      * Interface for actions executed in the context of fresh (non-expired) tokens.
      * @see #performActionWithFreshTokens(AuthorizationService, AuthStateAction)
@@ -741,6 +762,22 @@ public class AuthState {
                 @Nullable String accessToken,
                 @Nullable String idToken,
                 @Nullable AuthorizationException ex);
+    }
+
+    /**
+     * Interface for listening to AuthState updates.
+     * @see #addUpdateListener(AuthStateListener)
+     */
+    public abstract static class AuthStateListener {
+        /**
+         * Executed in the context of a successful Auth State update.
+         */
+        public abstract void authStateDidUpdate(@NonNull AuthState state);
+
+        /**
+         * Executed in the context of a Auth State update failure.
+         */
+        public void authStateDidFailToUpdate(AuthorizationException ex) { }
     }
 
     /**


### PR DESCRIPTION
Creates a `AuthStateListener` abstract class for getting notifications on `AuthState` updates. It allows us to perform actions such as saving the updated state locally.

```java
AuthState state = readState();

state.addUpdateListener(new AuthState.AuthStateListener() {

    @Override
    public void authStateDidUpdate(@NonNull AuthState state) {
        writeState(state);
    }
});
```